### PR TITLE
Convert Instructions to a CFG and do live variable analysis

### DIFF
--- a/lib/fisk/basic_block.rb
+++ b/lib/fisk/basic_block.rb
@@ -1,0 +1,163 @@
+class Fisk
+  class CFG < Struct.new(:variables, :blocks)
+    class BasicBlock < Struct.new(:name, :insns, :fall, :jump, :def, :use, :in, :out, :pred, :start_point, :end_point)
+      def jump?
+        insns.last.jump?
+      end
+
+      def jump_name
+        insns.last.target
+      end
+
+      def succ
+        list = []
+        list << fall if fall
+        list << jump if jump
+        list
+      end
+
+      def live; self.def | self.use | self.out; end
+    end
+
+    def self.build instructions
+      blocks = []
+      bb_index = 0
+
+      chunks = instructions.chunk { |insn|
+        if insn.label?
+          # start a new block here
+          bb_index += 1
+        end
+
+        ret_idx = bb_index
+
+        if insn.jump?
+          # end the block here
+          bb_index += 1
+        end
+
+        ret_idx
+      }.to_a
+
+      chunk_name = ->(chunk_id, insns) {
+        if insns.first.label?
+          insns.first.name
+        else
+          :"bb_#{chunk_id}"
+        end
+      }
+
+      jump_targets = {}
+      wants_target = []
+      insn_idx = 0
+
+      chunks.each_with_index do |(chunk_id, insns), idx|
+        prev_block = blocks.last
+
+        name = chunk_name.(chunk_id, insns)
+
+        next_chunk_id, next_insns = chunks[idx + 1]
+
+        outgoing = []
+
+        if next_chunk_id
+          outgoing << chunk_name.(next_chunk_id, next_insns)
+        end
+
+        bb = BasicBlock.new(name, insns)
+        bb.pred = []
+        bb.start_point = insn_idx
+        insn_idx += insns.length
+        bb.end_point = insn_idx - 1
+
+        if bb.jump?
+          target_name = bb.jump_name
+
+          # if we need to jump backwards, the label should already be filled in.
+          # Otherwise we need to find the block later (we're jumping forward)
+          if jump_targets[target_name]
+            jt = jump_targets[target_name]
+            bb.jump = jt
+            jt.pred << bb
+          else
+            wants_target << bb
+          end
+        end
+
+        jump_targets[bb.name] = bb
+
+        if prev_block
+          prev_block.fall = bb
+          bb.pred << prev_block
+        end
+
+        blocks << bb
+      end
+
+      # fill in any forward jumps
+      wants_target.each { |bb|
+        jt = jump_targets[bb.jump_name]
+        bb.jump = jt
+        jt.pred << bb
+      }
+
+      variables = live_variables blocks
+
+      CFG.new variables, blocks
+    end
+
+    def self.live_variables blocks
+      seen = Set.new
+
+      blocks.each do |block|
+        used = Set.new
+        defd = Set.new
+
+        block.insns.each do |insn|
+          if insn.has_temp_registers?
+            insn.temp_registers.each do |reg|
+              defd << reg unless seen.include?(reg)
+              used << reg unless defd.include?(reg)
+              seen << reg
+            end
+          end
+        end
+
+        block.use = used.to_a
+        block.def = defd.to_a
+        block.in  = []
+        block.out = []
+      end
+
+      worklist = blocks.dup
+      while block = worklist.pop
+        block.out = block.succ.inject([]) { |out_registers, succ_block|
+          out_registers | succ_block.in
+        }
+        ins = block.in | block.use | (block.out - block.def)
+
+        if ins == block.in
+          # Done with this block!
+          block.live.each do |live_register|
+            live_register.start_point ||= block.start_point
+            live_register.end_point ||= block.end_point
+
+            if live_register.start_point > block.start_point
+              live_register.start_point = block.start_point
+            end
+
+            if live_register.end_point < block.end_point
+              live_register.end_point = block.end_point
+            end
+          end
+        else
+          block.in = ins
+          worklist.concat(block.pred)
+        end
+      end
+
+      seen
+    end
+  end
+
+end

--- a/test/test_cfg.rb
+++ b/test/test_cfg.rb
@@ -1,0 +1,246 @@
+require "helper"
+
+class Fisk
+  class CFGTest < Fisk::Test
+    attr_reader :fisk
+
+    def setup
+      super
+      @fisk = Fisk.new
+    end
+
+    def test_no_jumps
+      fisk.push fisk.r8
+      basic_blocks = fisk.basic_blocks
+      assert_equal 1, basic_blocks.length
+
+      block = basic_blocks.first
+      assert_nil block.jump
+      assert_nil block.fall
+    end
+
+    def test_simple_jump
+      fisk.push fisk.r8
+      fisk.jmp fisk.label(:foo)
+      fisk.put_label(:foo)
+      fisk.nop
+
+      basic_blocks = fisk.basic_blocks
+      assert_equal 2, basic_blocks.length
+
+      block = basic_blocks.first
+      assert_equal :foo, block.jump.name
+      assert_equal :foo, block.fall.name
+
+      block2 = basic_blocks.last
+      assert_nil block2.jump
+      assert_nil block2.fall
+    end
+
+    def test_jump_and_fall
+      fisk.push fisk.r8
+      fisk.jmp fisk.label(:foo)
+      fisk.nop
+      fisk.nop
+      fisk.nop
+      fisk.put_label(:foo)
+      fisk.nop
+
+      blocks = fisk.basic_blocks
+      assert_equal 3, blocks.length
+
+      assert_predicate blocks[0], :jump?
+
+      assert_equal :foo, blocks[0].jump.name
+      assert_equal blocks[2], blocks[0].jump
+      assert_equal :foo, blocks[2].name
+
+      assert blocks[0].jump
+      assert blocks[0].fall
+      assert blocks[1].fall
+      refute blocks[1].jump
+      refute blocks[2].fall
+      refute blocks[2].jump
+    end
+
+    def test_jump_backwards
+      fisk.push fisk.r8
+      fisk.put_label(:foo)
+      fisk.nop
+      fisk.put_label(:bar)
+      fisk.nop
+      fisk.jmp fisk.label(:foo)
+      fisk.nop
+      fisk.nop
+
+      blocks = fisk.basic_blocks
+      assert_equal 4, blocks.length
+
+      refute_predicate blocks[0], :jump?
+      refute_predicate blocks[1], :jump?
+      assert_predicate blocks[2], :jump?
+      assert_equal blocks[1], blocks[2].jump
+    end
+
+    def test_jump_self
+      fisk.put_label(:foo)
+      fisk.nop
+      fisk.nop
+      fisk.jmp fisk.label(:foo)
+      fisk.nop
+      fisk.nop
+
+      blocks = fisk.basic_blocks
+      assert_equal 2, blocks.length
+
+      assert_predicate blocks[0], :jump?
+      refute_predicate blocks[1], :jump?
+      assert_equal blocks[0], blocks[0].jump
+      assert_equal blocks[1], blocks[0].fall
+    end
+
+    def test_loop
+      __ = fisk
+      reg1 = fisk.r9
+      reg2 = fisk.r10
+      reg3 = fisk.rax
+
+      __.mov(reg1, __.imm32(1))    # block 0
+        .mov(reg2, __.imm32(1))
+        .put_label(:head)          # block 1
+        .cmp(reg1, __.imm32(100))
+        .ja(__.label(:break))
+        .add(reg1, reg2)           # block 2
+        .mov(reg3, __.imm32(1))
+        .mov(reg2, reg3)
+        .jmp(__.label(:head))
+        .put_label(:break)         # block 3
+
+      blocks = fisk.basic_blocks
+      assert_equal 4, blocks.length
+
+      refute_predicate blocks[0], :jump?
+      assert_predicate blocks[1], :jump?
+      assert_equal blocks.last, blocks[1].jump
+      assert_equal blocks[2], blocks[1].fall
+      assert_predicate blocks[2], :jump?
+      assert_equal blocks[1], blocks[2].jump
+    end
+
+    def test_use_def
+      __ = fisk
+
+      reg1 = fisk.register("temp1")
+      reg2 = fisk.register("temp2")
+      reg3 = fisk.register("temp3")
+
+      __.mov(reg1, fisk.imm32(1))    # block 0
+        .mov(reg2, fisk.imm32(1))
+      .put_label(:head)              # block 1
+        .cmp(reg1, fisk.imm32(100))
+        .jg(fisk.label(:break))
+        .add(reg1, reg2)             # block 2
+        .mov(reg3, fisk.imm32(1))
+        .mov(reg2, reg3)
+        .jmp(fisk.label(:head))
+      .put_label(:break)             # block 3
+
+      blocks = fisk.basic_blocks
+
+      assert_equal [reg1, reg2], blocks[0].def
+      assert_equal [], blocks[0].use
+
+      assert_equal [], blocks[1].def
+      assert_equal [reg1], blocks[1].use
+
+      assert_equal [reg3], blocks[2].def
+      assert_equal [reg1, reg2], blocks[2].use
+
+      assert_equal [], blocks[3].def
+      assert_equal [], blocks[3].use
+    end
+
+    def test_pred
+      __ = fisk
+
+      reg1 = fisk.register("temp1")
+      reg2 = fisk.register("temp2")
+      reg3 = fisk.register("temp3")
+
+      __.mov(reg1, fisk.imm32(1))    # block 0
+        .mov(reg2, fisk.imm32(1))
+      .put_label(:head)              # block 1
+        .cmp(reg1, fisk.imm32(100))
+        .jg(fisk.label(:break))
+        .add(reg1, reg2)             # block 2
+        .mov(reg3, fisk.imm32(1))
+        .mov(reg2, reg3)
+        .jmp(fisk.label(:head))
+      .put_label(:break)             # block 3
+
+      blocks = fisk.basic_blocks
+
+      assert_equal [blocks[1], blocks[2]].map(&:name).sort, blocks[3].pred.map(&:name).sort
+      assert_equal [blocks[1]].map(&:name).sort, blocks[2].pred.map(&:name).sort
+      assert_equal [blocks[0], blocks[2]].map(&:name).sort, blocks[1].pred.map(&:name).sort
+      assert_equal [], blocks[0].pred
+    end
+
+    def test_live
+      __ = fisk
+
+      reg1 = fisk.register("temp1")
+      reg2 = fisk.register("temp2")
+      reg3 = fisk.register("temp3")
+
+      __.mov(reg1, fisk.imm32(1))    # block 0
+        .mov(reg2, fisk.imm32(1))
+      .put_label(:head)              # block 1
+        .cmp(reg1, fisk.imm32(100))
+        .jg(fisk.label(:break))
+        .add(reg1, reg2)             # block 2
+        .mov(reg3, fisk.imm32(1))
+        .mov(reg2, reg3)
+        .jmp(fisk.label(:head))
+      .put_label(:break)             # block 3
+
+      blocks = fisk.basic_blocks
+
+
+      assert_equal [reg1, reg2].map(&:name).sort,       blocks[0].live.map(&:name).sort
+      assert_equal [reg1, reg2].map(&:name).sort,       blocks[1].live.map(&:name).sort
+      assert_equal [reg1, reg2, reg3].map(&:name).sort, blocks[2].live.map(&:name).sort
+      assert_equal [],                                  blocks[3].live
+    end
+
+    def test_register_range
+      __ = fisk
+
+      reg1 = fisk.register("temp1")
+      reg2 = fisk.register("temp2")
+      reg3 = fisk.register("temp3")
+
+      __.mov(reg1, fisk.imm32(1))    # block 0
+        .mov(reg2, fisk.imm32(1))
+      .put_label(:head)              # block 1
+        .cmp(reg1, fisk.imm32(100))
+        .jg(fisk.label(:break))
+        .add(reg1, reg2)             # block 2
+        .mov(reg3, fisk.imm32(1))
+        .mov(reg2, reg3)
+        .jmp(fisk.label(:head))
+      .put_label(:break)             # block 3
+
+      blocks = fisk.basic_blocks
+
+
+      assert_equal 0, reg1.start_point
+      assert_equal 0, reg2.start_point
+      assert_equal 5, reg3.start_point
+
+      assert_equal 8, reg1.end_point
+      assert_equal 8, reg2.end_point
+      assert_equal 8, reg3.end_point
+    end
+  end
+end


### PR DESCRIPTION
This PR is for fixing #3.  It converts instructions to basic blocks, does live variable analysis on any temporary registers, and then uses that information to assign lifetime ranges to temporary registers.  Register assignment still uses the "linear scan" method, but live variable analysis fixes the "loop" problem in #3 