### PR TITLE
Raise an exception when trying to encode unassigned registers

### DIFF
--- a/lib/fisk.rb
+++ b/lib/fisk.rb
@@ -97,19 +97,27 @@ class Fisk
       def temp_register?; true; end
 
       def op_value
-        @register.op_value
+        reg.op_value
       end
 
       def extended_register?
-        @register.extended_register?
+        reg.extended_register?
       end
 
       def rex_value
-        @register.rex_value
+        reg.rex_value
       end
 
       def value
-        @register.value
+        reg.value
+      end
+
+      def reg
+        unless @register
+          raise Errors::UnassignedRegister, "Temporary register #{name} hasn't been assigned a real register"
+        end
+
+        @register
       end
     end
 

--- a/lib/fisk/errors.rb
+++ b/lib/fisk/errors.rb
@@ -15,5 +15,10 @@ class Fisk
     # allocation was requested
     class UnreleasedRegisterError < Error
     end
+
+    # Raised when a temporary register hasn't been assigned a real register,
+    # but it's used in the encoding process.
+    class UnassignedRegister < Error
+    end
   end
 end

--- a/test/test_register_allocation.rb
+++ b/test/test_register_allocation.rb
@@ -8,6 +8,15 @@ class RegisterAllocationTest < Fisk::Test
     @fisk = Fisk.new
   end
 
+  def test_encode_temp_register_without_assignemt_raises
+    reg = fisk.register
+    fisk.push(reg)
+
+    assert_raises Fisk::Errors::UnassignedRegister do
+      fisk.to_binary
+    end
+  end
+
   def test_push_r8_with_reg_assignment
     reg = fisk.register
     fisk.push(reg)


### PR DESCRIPTION
If you forget to call `assign_registers`, but then try to encode the
instructions, you'll get a "method called on nil" exception.  That isn't
very helpful, so this commit adds an exception to let you know you
forgot to assign registers