### PR TITLE
Add an optional block to `put_label`

### DIFF
--- a/lib/fisk.rb
+++ b/lib/fisk.rb
@@ -284,8 +284,21 @@ class Fisk
     def comment?;            false; end
   end
 
-  class Label < Struct.new(:name)
+  class Label
     include InstructionPredicates
+
+    attr_reader :name, :pos
+
+    def initialize name, &blk
+      @name = name
+      @pos  = nil
+      @blk  = blk
+    end
+
+    def set_pos pos
+      @pos = pos
+      @blk.call(pos) if @blk
+    end
 
     def label?; true; end
   end
@@ -461,8 +474,10 @@ class Fisk
   end
 
   # Insert a label named +name+ at the current position in the instructions.
-  def put_label name
-    @instructions << Label.new(name)
+  # Takes an optional block which will get the position associated with the
+  # label.
+  def put_label name = nil, &block
+    @instructions << Label.new(name, &block)
     self
   end
   alias :make_label :put_label
@@ -606,6 +621,7 @@ class Fisk
     @instructions.each do |insn|
       if insn.label?
         labels[insn.name] = buffer.pos
+        insn.set_pos buffer.pos
       elsif insn.comment?
         comments.update({buffer.pos => insn.message}) { |_, *lines| lines.join($/) }
       else

--- a/test/test_fisk.rb
+++ b/test/test_fisk.rb
@@ -8,6 +8,36 @@ class FiskTest < Fisk::Test
     @fisk = Fisk.new
   end
 
+  def test_put_anon_label_block
+    found = nil
+    fisk.mov(fisk.rax, fisk.rip(fisk.label(:foo)))
+    fisk.nop
+    fisk.nop
+    fisk.nop
+    fisk.put_label { |pos| found = pos }
+
+    assert_nil found
+    fisk.to_binary
+    assert_equal 10, found
+  end
+
+  def test_put_label_block
+    found = nil
+    fisk.mov(fisk.rax, fisk.rip(fisk.label(:foo)))
+    fisk.nop
+    fisk.nop
+    fisk.nop
+    fisk.put_label(:foo) { |pos| found = pos }
+    fisk.jmp(fisk.label(:foo))
+
+    assert_nil found
+    insns = disasm(fisk.to_binary)
+    assert_equal 10, found
+
+    x = insns.find { |insn| insn.address == found }
+    assert_equal "jmp", x.mnemonic.to_s
+  end
+
   def test_rip_to_label
     fisk.mov(fisk.rax, fisk.rip(fisk.label(:foo)))
     fisk.nop


### PR DESCRIPTION
This optional block is called with the buffer output position when the
instructions get encoded.  This is useful for calculating patch locations