### PR TITLE
Add support for XMM regs to OperandSize#compute_size

### DIFF
--- a/lib/fisk.rb
+++ b/lib/fisk.rb
@@ -22,6 +22,8 @@ class Fisk
 
   module OperandSize
     def compute_size type
+      return 128 if type.start_with?('xmm')
+
       bits = type[/^r(\d+)$/, 1]&.to_i
 
       if bits.nil?


### PR DESCRIPTION
Used to introduce testing for stack alignment in TenderJIT.

It'd be best to formally add XMM registers, but this is currently enough.