### PR TITLE
Don't use memory that is both writable and executable

### DIFF
--- a/lib/fisk.rb
+++ b/lib/fisk.rb
@@ -792,6 +792,16 @@ class Fisk
   # If the performance check is enabled, a runtime error is raised if suboptimal
   # instructions are found.
   def write_to buffer, metadata: {}
+    if buffer.respond_to? :allow_writes
+      buffer.allow_writes do
+        _write_to buffer, metadata: metadata
+      end
+    else
+      _write_to buffer, metadata: metadata
+    end
+  end
+
+  private def _write_to buffer, metadata: {}
     labels = {}
     comments = {}
     unresolved = []


### PR DESCRIPTION
The main reason to do this is that it is more secure, as memory
that is both writable and executable is a security risk. It is
also portable to systems that do not allow memory that is both
writable and executable (OpenBSD by default, NetBSD and Linux
with security patches).

Initialize memory as read-execute.  While writing, mprotect it to
read-write, then back to read-execute afterward.

There may be other places that allow memory writing besides write_to
and this would break those cases.  I didn't audit the code to look
for additional spots where you would need to call allow_writes.

Not sure whether this works.  The tests don't run on OpenBSD and
the example segfaults with or without this change.

I'm marking this as draft, since I'm guessing there are
multiple issues with it, assuming it works at all.