### PR TITLE
Remove redundant workaround of Crabstone

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,18 +4,6 @@ require "crabstone"
 ENV["MT_NO_PLUGINS"] = "1"
 require "minitest/autorun"
 
-# https://github.com/bnagy/crabstone/issues/10
-class Crabstone::Binding::Instruction
-  class << self
-    alias :old_release :release
-  end
-
-  # Squelch error in crabstone
-  def self.release obj
-    nil
-  end
-end
-
 class Fisk::Test < Minitest::Test
   def print_disasm binary
     cs = Crabstone::Disassembler.new(Crabstone::ARCH_X86, Crabstone::MODE_64)


### PR DESCRIPTION
The [Crabstone gem](https://rubygems.org/gems/crabstone) used by Fisk is maintained by me, where the memory leak issue mentioned in https://github.com/bnagy/crabstone/issues/10 is already fixed.

Tested `bundle exec rake` passed.